### PR TITLE
Support newer versions of objdump

### DIFF
--- a/objdump_check.py
+++ b/objdump_check.py
@@ -65,7 +65,7 @@ def DisassembleTestCallback(get_instructions, bits):
 whitespace_regexp = re.compile('\s+')
 comment_regexp = re.compile('\s+#.*$')
 jump_regexp = re.compile(
-    '^(jn?[a-z]{1,2}|call|jmp[lw]?|je?cxz|loop(e|ne)?) 0x[0-9a-f]+$')
+    '^(jn?[a-z]{1,2}|call|jmp[lw]?|j[er]?cxz|loop(e|ne)?) 0x[0-9a-f]+$')
 rex_regexp = re.compile(r'rex(\.W?R?X?B?)? ')
 
 
@@ -86,6 +86,10 @@ def NormaliseObjdumpDisasm(disasm):
             .replace('0x1111', 'VALUE16')
             .replace('0x11', 'VALUE8')
             .replace(',', ', '))
+  # Remove data32 annotations.
+  disasm = disasm.replace('data32 ', '')
+  # Replace movabs with mov.
+  disasm = disasm.replace('movabs', 'mov')
   return disasm
 
 


### PR DESCRIPTION
Resolved incompatibilities with newer versions of `objdump`. The most significant change seems to be the newly introduced behaviour where `objdump` interprets arbitrary long sequences of `0x66` bytes as `data32` annotations. However, this does not seem to be valid according to the AMD manual nor `gcc`. To allow crosschecking against newer versions, the cross-checking scripts strips out these annotations.

Alternatively, we could extend the validator to output `data32` annotations, but in that case we would have to perform some post-processing as well i.e. strip them or replace them with `.byte 0x66` in the input which is being fed to `gcc` during cross-check.
